### PR TITLE
Fixed workflow bug: Error: 😭 unable to extract version info!

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: NuGet publish
+name: NuGet Publish
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Obfuscation.Fody
 
+[![.NET Build](https://github.com/VAllens/Obfuscation.Fody/actions/workflows/build.yml/badge.svg?branch=develop&event=push)](https://github.com/VAllens/Obfuscation.Fody/actions/workflows/build.yml) [![NuGet Publish](https://github.com/VAllens/Obfuscation.Fody/actions/workflows/publish.yml/badge.svg?branch=main&event=pull_request)](https://github.com/VAllens/Obfuscation.Fody/actions/workflows/publish.yml)
+
 ## This is a [Fody](https://github.com/Fody/Fody) extension to modify `ObfuscationAttribute`.
 
 It will get the attribute target that contains `ObfuscationAttribute`, and filter out the attribute target whose `Exclude` property value is equal to `true`, and modify the eligible `Feature` property value. Other properties remain the same.


### PR DESCRIPTION
```log
Project Filepath: src/Obfuscation.Fody.NuGet/Obfuscation.Fody.NuGet.csproj
Version Filepath: src/Obfuscation.Fody.NuGet/Obfuscation.Fody.NuGet.csproj
Version Regex: /^\s*<Version>(.*)<\/Version>\s*$/m
Error: 😭 unable to extract version info!
/home/runner/work/_actions/rohith/publish-nuget/v2/index.js:23
        throw new Error(msg)
        ^

Error: unable to extract version info!
    at Action._printErrorAndExit (/home/runner/work/_actions/rohith/publish-nuget/v2/index.js:23:15)
    at Action.run (/home/runner/work/_actions/rohith/publish-nuget/v2/index.js:[13](https://github.com/VAllens/Obfuscation.Fody/runs/5226187309?check_suite_focus=true#step:9:13)4:22)
    at Object.<anonymous> (/home/runner/work/_actions/rohith/publish-nuget/v2/index.js:[14](https://github.com/VAllens/Obfuscation.Fody/runs/5226187309?check_suite_focus=true#step:9:14)5:14)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:8[15](https://github.com/VAllens/Obfuscation.Fody/runs/5226187309?check_suite_focus=true#step:9:15):32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1047:10)
    at internal/main/run_main_module.js:[17](https://github.com/VAllens/Obfuscation.Fody/runs/5226187309?check_suite_focus=true#step:9:17):11
```